### PR TITLE
Fix format_time to account for 0:00 format instead of 0:0

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -249,8 +249,10 @@ def format_time(secs):
     sec = secs%60
     minute = secs//60
     hour = minute//60
-
-    mat = " " + str(minute) + ":" + str(sec)
+    if sec < 10:
+        mat = " " + str(minute) + ":0" + str(sec)
+    else:
+        mat = " " + str(minute) + ":" + str(sec)
     return mat
 
 


### PR DESCRIPTION
Originally if the sec was less than 10 seconds, time format looked something like these:

0:0
4:2
1:5

With this change, time should look more like this:

0:00
4:20
1:50